### PR TITLE
Accept uppercase extension for additional images

### DIFF
--- a/samples/download-sample
+++ b/samples/download-sample
@@ -20,3 +20,5 @@ fi
 mkdir samples/content
 unzip "$ZIP" -d "$OUT"
 rm "$ZIP"
+# Create a file with uppercase extension
+cp "$OUT/cover.jpg" "$OUT/UPPERCASE.JPG"

--- a/src/commands/transcode/additional_job_factory.rs
+++ b/src/commands/transcode/additional_job_factory.rs
@@ -58,7 +58,8 @@ impl AdditionalJobFactory {
             .extension()
             .expect("Source has extension")
             .to_string_lossy()
-            .to_string();
+            .to_string()
+            .to_lowercase();
         let is_image = IMAGE_EXTENSIONS.contains(&extension.as_str());
         let is_large = size > max_file_size;
         let no_image_compression = self

--- a/src/commands/transcode/tests/transcode_command_tests.rs
+++ b/src/commands/transcode/tests/transcode_command_tests.rs
@@ -63,7 +63,7 @@ async fn transcode_command() -> Result<(), Error> {
         .with_extension("jpg")
         .read(&output_dir)
         .expect("Should be able to read dir");
-    assert_eq!(generated_files.len(), target_count);
+    assert_eq!(generated_files.len(), target_count * 2); // 2 covers per target
     let cover = generated_files.first().expect("should be at least one");
     let hard_links = metadata(cover)
         .expect("should be able to get metadata")

--- a/src/utils/fs/collector.rs
+++ b/src/utils/fs/collector.rs
@@ -29,7 +29,7 @@ impl Collector {
         collection
     }
 
-    /// Create [`AdditionalFile`] for each additonal file in a directory.
+    /// Create [`AdditionalFile`] for each additional file in a directory.
     #[must_use]
     pub fn get_additional(source_dir: &PathBuf) -> Vec<AdditionalFile> {
         let paths = DirectoryReader::new()

--- a/src/utils/fs/directory_reader.rs
+++ b/src/utils/fs/directory_reader.rs
@@ -67,7 +67,7 @@ impl DirectoryReader {
         if self.included_extensions.is_empty() {
             true
         } else if let Some(extension) = path.extension() {
-            let extension = extension.to_string_lossy().to_string();
+            let extension = extension.to_string_lossy().to_string().to_lowercase();
             self.included_extensions.contains(&extension)
         } else {
             false


### PR DESCRIPTION
Hi,
Thanks for the tool!
Before this PR, artwork such as "cover.JPG" is ignored because of the uppercase extension. This fixes it.
