### PR TITLE
Handle "letter only" vinyl numbering

### DIFF
--- a/crates/core/src/utils/fs/tags.rs
+++ b/crates/core/src/utils/fs/tags.rs
@@ -79,10 +79,12 @@ fn replace_total_track_numbering(tags: &mut Tag) -> Result<(), Error> {
 }
 
 pub(crate) fn get_numeric_from_vinyl_format(input: &str) -> Option<(u32, u32)> {
-    let re = Regex::new(r"^([A-Z])(\d+)$").ok()?;
+    // Vinyl format is typically "A1", "B2", etc., where the letter represents the disc and the number represents the track.
+    // It might also be just a letter without a number when there's a single track on a side, like "A" or "B".
+    let re = Regex::new(r"^([A-Z])(\d+)?$").ok()?;
     let captures = re.captures(input)?;
     let disc_letter = captures.get(1)?.as_str().chars().next()?;
-    let track_number: u32 = captures.get(2)?.as_str().parse().ok()?;
+    let track_number: u32 = captures.get(2).map_or(Ok(1), |m| m.as_str().parse()).ok()?;
     let disc_number = letter_to_number(disc_letter)?;
     Some((disc_number, track_number))
 }

--- a/crates/core/src/utils/fs/tests/tags_tests.rs
+++ b/crates/core/src/utils/fs/tests/tags_tests.rs
@@ -20,6 +20,8 @@ fn invalid_total_formats() {
 #[test]
 fn valid_vinyl_formats() {
     assert_eq!(get_numeric_from_vinyl_format("A1"), Some((1, 1)));
+    assert_eq!(get_numeric_from_vinyl_format("A"), Some((1, 1)));
+    assert_eq!(get_numeric_from_vinyl_format("B"), Some((2, 1)));
     assert_eq!(get_numeric_from_vinyl_format("A12"), Some((1, 12)));
     assert_eq!(get_numeric_from_vinyl_format("B6"), Some((2, 6)));
     assert_eq!(get_numeric_from_vinyl_format("C8"), Some((3, 8)));
@@ -29,7 +31,6 @@ fn valid_vinyl_formats() {
 #[test]
 fn invalid_vinyl_formats() {
     assert_eq!(get_numeric_from_vinyl_format(""), None);
-    assert_eq!(get_numeric_from_vinyl_format("A"), None);
     assert_eq!(get_numeric_from_vinyl_format("12"), None);
     assert_eq!(get_numeric_from_vinyl_format("1A"), None);
 }


### PR DESCRIPTION
For single track sides.

Seems to be a commonly accepted behavior on RED, as many single track sides are just numbered "A" instead of "A1".