### PR TITLE
docs: correct inspect command arg and clarify docker path handling

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -33,12 +33,12 @@ caesura config
 
 The inspect command can be used on any directory of `.flac` or `.mp3` files.
 
-It prints a table of metadata for each file followed by printing every tag and embeded image in the file.
+It prints a table of metadata for each file followed by printing every tag and embedded image in the file.
 
 It's useful for checking that the metadata of a source is correct before transcoding.
 
 ```bash
-caesura inspect 142659
+caesura inspect "/path/to/Artist - Album"
 ```
 
 ![](https://media.githubusercontent.com/media/RogueOneEcho/assets-caesura/main/dist/inspect.gif)

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -46,6 +46,8 @@ Refer to the [setup guide](SETUP.md) for more information on configuring caesura
 
 The [command guide](COMMANDS.md) shows commands in native form. To run them with Docker Compose, prefix with `docker compose run --rm caesura`.
 
+Any path used in the config file or passed to a command must be the path as seen inside the container. In the example compose file, `/srv/shared` is mounted at the same path inside the container, so values such as `/srv/shared/downloads/content` work in both places. If you mount a host directory somewhere else in the container, use the container-side path.
+
 For example, the native version command is:
 
 ```bash
@@ -56,6 +58,12 @@ For docker compose use:
 
 ```bash
 docker compose run --rm caesura version
+```
+
+The same rule applies to command arguments. To inspect an album directory mounted by the example compose file:
+
+```bash
+docker compose run --rm caesura inspect "/srv/shared/downloads/content/Artist - Album"
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Clarify that Docker config values and command path arguments use container paths.
- Add a Docker Compose `inspect` example using the mounted content path.
- Correct the `inspect` command example to use a directory path and fix the embedded typo.

## Testing
- `git diff --check`
- Not run: Rust test suite; docs-only change.
