### PR TITLE
test(spectrogram): normalize SoX-dependent widths of full spectrograms

### DIFF
--- a/crates/core/src/utils/testing/snapshots/file_snapshot.rs
+++ b/crates/core/src/utils/testing/snapshots/file_snapshot.rs
@@ -80,9 +80,9 @@ fn read_snap_body(snap_path: &Path) -> Option<String> {
 /// Patch platform-dependent fields from a stored insta snapshot.
 ///
 /// On platforms where audio encoding produces bitwise-different output (ARM,
-/// Nix), replaces SHA-256, file-size, and bitrate fields in `files` with values
-/// from the stored snapshot so that structural comparison via
-/// `assert_yaml_snapshot!` still works.
+/// Nix), replaces SHA-256, file-size, bitrate, and full-spectrogram width fields
+/// in `files` with values from the stored snapshot so that structural comparison
+/// via `assert_yaml_snapshot!` still works.
 pub fn patch_platform_dependent_fields(files: &mut [FileSnapshot], snap_path: &Path) {
     let Some(yaml_body) = read_snap_body(snap_path) else {
         return;
@@ -93,6 +93,11 @@ pub fn patch_platform_dependent_fields(files: &mut [FileSnapshot], snap_path: &P
     for (actual, stored) in files.iter_mut().zip(stored.iter()) {
         actual.sha256.clone_from(&stored.sha256);
         actual.size = stored.size;
+        if actual.filename.ends_with(".full.png")
+            && let (Some(actual_image), Some(stored_image)) = (&mut actual.image, &stored.image)
+        {
+            actual_image.width = stored_image.width;
+        }
         if let (Some(actual_audio), Some(stored_audio)) = (&mut actual.audio, &stored.audio) {
             actual_audio.overall_bitrate = stored_audio.overall_bitrate;
             actual_audio.audio_bitrate = stored_audio.audio_bitrate;

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -164,7 +164,7 @@ CAESURA_DETERMINISTIC_TESTS=1 cargo test
 | `transcode_command_*`        | `normalize_snapshots!`     | SHA-256, file-size, and bitrate ignored                                                                 |
 | `transcode_rename_tracks_*` | `normalize_snapshots!`     | SHA-256, file-size, and bitrate ignored                                                                 |
 | `inspect_*`                  | `assert_inspect_snapshot!` | Line count only                                                                               |
-| `spectrogram_command_*`      | `normalize_snapshots!`     | SHA-256, file-size, and bitrate ignored                                                                 |
+| `spectrogram_command_*`      | `normalize_snapshots!`     | SHA-256, file-size, bitrate, and full-spectrogram width ignored                                          |
 | `sample_flac*`               | `#[ignore]`                | Ignored, CI only runs on x86_64 Linux via<br>`cargo test --release -- --ignored sample_flac` |
 
 ### Updating Snapshots


### PR DESCRIPTION
This PR normalizes the width of `*.full.png` spectrograms in non-deterministic tests.
Valid output can differ slightly across versions and builds of both SoX and SoX_ng.
I reproduced this issue with different SoX_ng versions and builds, which caused two snapshot tests to fail.

The change only covers the width of full spectrograms. Deterministic tests remain unchanged, and `docs/TESTING.md` now documents this behavior.

## Disclosure

I used LLMs (GPT-5.6-sol) for translation and to help me understand how things fit together in your codebase.